### PR TITLE
Use CDATA to escape request xml text

### DIFF
--- a/translator/translator.go
+++ b/translator/translator.go
@@ -191,7 +191,7 @@ func requestXML(from string, to string, input []string, inputType string) string
 	texts := func(in []string) string {
 		var out string
 		for _, t := range in {
-			out += fmt.Sprintf("<string xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\">%s</string>", t)
+			out += fmt.Sprintf("<string xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><![CDATA[%s]]></string>", t)
 		}
 		return out
 	}(input)


### PR DESCRIPTION
Hi, the text set in request xml should be escaped/wrapped by CDATA, otherwise the following code will panic:

``` go
package main

import (
    btr "github.com/theplant/bingtranslator/translator"
)

func Main(t *testing.T) {
    btr.SetCredentials("blah blah", "blah blah")

    translations, err := btr.Translate("zh-CHS", "en", []string{"Lulin Arts&Cralts/绿"}, btr.INPUT_TEXT)
    if err != nil {
        panic(err)
        return
    }

    if translations == nil {
      panic("translations nil")
    }
}
```
